### PR TITLE
Upgrade gem dependencies

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_JOBS: 4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,8 @@ PATH
   specs:
     guignol (0.3.14)
       activesupport
-      fog (~> 1.12.0)
+      excon
+      fog-aws
       parallel (~> 0.6.2)
       thor (>= 0.15)
       uuidtools
@@ -11,45 +12,49 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.2)
+    activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     builder (3.2.2)
-    coderay (1.0.9)
-    diff-lcs (1.2.4)
-    excon (0.23.0)
-    fog (1.12.1)
+    coderay (1.1.0)
+    diff-lcs (1.2.5)
+    excon (0.45.4)
+    fog-aws (0.7.6)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.35.0)
       builder
-      excon (~> 0.23.0)
-      formatador (~> 0.2.0)
-      mime-types
-      multi_json (~> 1.0)
-      net-scp (~> 1.1)
-      net-ssh (>= 2.1.3)
-      nokogiri (~> 1.5.0)
-      ruby-hmac
+      excon (~> 0.45)
+      formatador (~> 0.2)
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
     i18n (0.7.0)
+    ipaddress (0.8.0)
     json (1.8.3)
-    method_source (0.8.1)
-    mime-types (2.6.1)
-    minitest (5.7.0)
-    multi_json (1.11.1)
-    net-scp (1.1.2)
-      net-ssh (>= 2.6.5)
-    net-ssh (2.8.0)
-    nokogiri (1.5.11)
+    method_source (0.8.2)
+    mini_portile (0.6.2)
+    minitest (5.8.3)
+    multi_json (1.11.2)
+    nokogiri (1.6.6.4)
+      mini_portile (~> 0.6.0)
     parallel (0.6.5)
-    pry (0.9.12.2)
-      coderay (~> 1.0.5)
-      method_source (~> 0.8)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-nav (0.2.3)
-      pry (~> 0.9.10)
-    rake (10.1.0)
+    pry-nav (0.2.4)
+      pry (>= 0.9.10, < 0.11.0)
+    rake (10.4.2)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -58,13 +63,12 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
-    ruby-hmac (0.4.0)
-    slop (3.4.5)
+    slop (3.6.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uuidtools (2.1.4)
+    uuidtools (2.1.5)
 
 PLATFORMS
   ruby
@@ -76,3 +80,6 @@ DEPENDENCIES
   pry-nav
   rake
   rspec (~> 2.13.0)
+
+BUNDLED WITH
+   1.10.6

--- a/guignol.gemspec
+++ b/guignol.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-nav"
 
 
-  s.add_dependency "fog", "~> 1.12.0"
+  s.add_dependency "fog-aws"
+  s.add_dependency "excon"
   s.add_dependency "parallel", '~> 0.6.2'
   s.add_dependency "activesupport"
   s.add_dependency "uuidtools"

--- a/lib/guignol/connection.rb
+++ b/lib/guignol/connection.rb
@@ -1,5 +1,5 @@
 
-require 'fog'
+require 'fog/aws'
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/hash/reverse_merge'
 require 'guignol/configuration'

--- a/lib/guignol/models/instance.rb
+++ b/lib/guignol/models/instance.rb
@@ -1,6 +1,7 @@
 require 'erb'
 require 'yaml'
-require 'fog'
+require 'ostruct'
+require 'fog/aws'
 require 'active_support/core_ext/hash/slice'
 require 'guignol'
 require 'guignol/models/base'

--- a/lib/guignol/models/volume.rb
+++ b/lib/guignol/models/volume.rb
@@ -1,5 +1,5 @@
 
-require 'fog'
+require 'fog/aws'
 require 'active_support/core_ext/hash/slice'
 require 'guignol'
 require 'guignol/models/base'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'rspec'
 require 'rspec/mocks'
-require 'fog'
+require 'fog/aws'
 
 Fog.mock!
 


### PR DESCRIPTION
:gem: Upgrade gem dependencies for recent Nokogiri vulnerability
:memo: Also uses only fog-aws instead of the full fog gem, as that is all we need.